### PR TITLE
Make paper plugin and update CommandAPI to 11.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,15 @@ allprojects {
 }
 
 dependencies {
-    annotationProcessor "dev.jorel:commandapi-annotations:9.7.0"
+    annotationProcessor "dev.jorel:commandapi-annotations:11.0.0"
 
     // Paper API
     compileOnly "io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT"
 
     // CommandAPI
-    implementation "dev.jorel:commandapi-bukkit-shade:9.7.0"
+    implementation "dev.jorel:commandapi-paper-shade:11.0.0"
 
-    compileOnly "dev.jorel:commandapi-annotations:9.7.0"
+    compileOnly "dev.jorel:commandapi-annotations:11.0.0"
 
     compileOnly 'io.github.fastily:jwiki:1.11.0'
 
@@ -61,7 +61,7 @@ processResources {
     def props = [version: version]
     inputs.properties props
     filteringCharset 'UTF-8'
-    filesMatching( 'plugin.yml' ) {
+    filesMatching( 'paper-plugin.yml' ) {
         expand props
 
     }

--- a/src/main/java/io/github/iherongh/wikicraft/WikiCraft.java
+++ b/src/main/java/io/github/iherongh/wikicraft/WikiCraft.java
@@ -1,7 +1,7 @@
 package io.github.iherongh.wikicraft;
 
 import dev.jorel.commandapi.CommandAPI;
-import dev.jorel.commandapi.CommandAPIBukkitConfig;
+import dev.jorel.commandapi.CommandAPIPaperConfig;
 import io.github.iherongh.wikicraft.account.WCAccountBridge;
 import io.github.iherongh.wikicraft.commands.WCCommandWiki;
 import io.github.iherongh.wikicraft.messages.WCMessages;
@@ -140,10 +140,7 @@ public class WikiCraft extends JavaPlugin {
     public void onLoad() {
         try {
             // Initialize CommandAPI
-            CommandAPI.onLoad( new CommandAPIBukkitConfig( this )
-                .skipReloadDatapacks( true )
-                .usePluginNamespace()
-            );
+            CommandAPI.onLoad( new CommandAPIPaperConfig( this ).silentLogs( true ) );
 
         } catch ( Exception e ) {
             WCMessages.throwError( e );

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -10,8 +10,12 @@ prefix: WikiCraft
 load: POSTWORLD
 license: MIT
 
-softdepend:
-    - LuckPerms
+depend:
+  server:
+    LuckPerms:
+      load: BEFORE
+      required: true
+      join-classpath: true
 
 libraries:
     - io.github.fastily:jwiki:1.11.0


### PR DESCRIPTION
This targets support for Minecraft versions 1.20.6 to 1.21.10 and drops support for servers not based on Paper (because of CommandAPI changes).

Success testing build, load, and enable on Purpur version 1.21.8-2485-HEAD@c29e75f (2025-07-31T05:02:22Z) (Implementing API version 1.21.8-R0.1-SNAPSHOT).

This fixes #1.